### PR TITLE
Add additional images to Apache Spark 3.5.0

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,6 +1,26 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
 GitRepo: https://github.com/apache/spark-docker.git
 
+Tags: 3.5.0-scala2.12-java17-python3-ubuntu, 3.5.0-java17-python3, 3.5.0-java17, python3-java17
+Architectures: amd64, arm64v8
+GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
+Directory: ./3.5.0/scala2.12-java17-python3-ubuntu
+
+Tags: 3.5.0-scala2.12-java17-r-ubuntu, 3.5.0-java17-r
+Architectures: amd64, arm64v8
+GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
+Directory: ./3.5.0/scala2.12-java17-r-ubuntu
+
+Tags: 3.5.0-scala2.12-java17-ubuntu, 3.5.0-java17-scala
+Architectures: amd64, arm64v8
+GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
+Directory: ./3.5.0/scala2.12-java17-ubuntu
+
+Tags: 3.5.0-scala2.12-java17-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
+Directory: ./3.5.0/scala2.12-java17-python3-r-ubuntu
+
 Tags: 3.5.0-scala2.12-java11-python3-ubuntu, 3.5.0-python3, 3.5.0, python3, latest
 Architectures: amd64, arm64v8
 GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7


### PR DESCRIPTION
This patch adds additional images to 3.5.0 version for Apache Spark https://spark.apache.org/docs/3.5.0/ [1]

[1] apache/spark-website#476
[2] apache/spark-docker#55